### PR TITLE
remove package name

### DIFF
--- a/neuronet_3/MLP.java
+++ b/neuronet_3/MLP.java
@@ -1,4 +1,4 @@
-package neuronet_3;
+package neuronet_3; //Should not be there
 
 import java.util.*;
 import java.io.*;


### PR DESCRIPTION
If we send just one .java file the name of the package should not be in the file, otherwise javac MLP.java yields an error.
